### PR TITLE
Keep indentation when using via CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ pids
 logs
 results
 
+node_modules
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ CLI usage
 ---------
 `sort-json file.json`
 
-For now sort-json takes no other arguments, so the origin file will be overritten by a sorted json file with 2-space indentation.
+For now sort-json takes no other arguments, so the original file will be overwritten by a sorted json file, keeping the indentation of the original file.

--- a/cmd.js
+++ b/cmd.js
@@ -2,12 +2,18 @@
 
 var fs = require('fs');
 var path = require('path');
+var detectIndent = require('detect-indent');
 
 var filename = path.resolve(process.argv[2]);
-var json = JSON.parse(fs.readFileSync(filename));
+var file = fs.readFileSync(filename, 'utf8');
+
+// Try to detect the indentation and fall back to two spaces if unable.
+var indent = detectIndent(file).indent || '  ';
+
+var json = JSON.parse(file);
 
 var visit = require('./');
 
 var result = visit(json);
 
-fs.writeFile(filename, JSON.stringify(result, null, '  '));
+fs.writeFile(filename, JSON.stringify(result, null, indent));

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.1.1",
   "description": "Takes a json-file and return a copy of the same file, but sorted",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "detect-indent": "^4.0.0"
+  },
   "bin": {
     "sort-json": "./cmd.js"
   },


### PR DESCRIPTION
When used via CLI, try to detect the indentation of the original file 
and use it when writing the sorted file.