### PR TITLE
fix: DeprecationWarning: Calling an asynchronous function without cal…

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -40,6 +40,11 @@ function readEachFile(fileName) {
     var sortedObject = sortJson(json);
 
     // Saving to file
-    fs.writeFile(filePath, JSON.stringify(sortedObject, null, indent) + ((eol && eol.length === 2) ? eol[1] : ''));
+    fs.writeFile(filePath, JSON.stringify(sortedObject, null, indent) + ((eol && eol.length === 2) ? eol[1] : ''), function(err) {
+      if (err) {
+        console.error(err);
+        process.exit(1);
+      }
+    });
   }
 }


### PR DESCRIPTION
I keep getting this warning from nodejs v7.1.0:
DeprecationWarning: Calling an asynchronous function without callback is deprecated.

This PR is a quickfix to remove the warning. Adds a callback function to writeFile.