### PR TITLE
run app/cmd.js instead of ./cmd.js when install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lodash": "^4.17.4"
   },
   "bin": {
-    "sort-json": "./cmd.js"
+    "sort-json": "./app/cmd.js"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
to fix issue #16 