### PR TITLE
Sorting's depth option added

### DIFF
--- a/app/cmd.js
+++ b/app/cmd.js
@@ -13,10 +13,12 @@ var sortJson = require('./');
 var files = process.argv.slice(0).filter(arg => arg.endsWith('.json') || arg.endsWith('.rc'));
 var ignoreCase = _.includes(process.argv, '--ignore-case') || _.includes(process.argv, '-i');
 var reverse = _.includes(process.argv, '--reverse') || _.includes(process.argv, '-r');
+var dirtyDepth = process.argv.slice(0).filter(arg => arg.startsWith('-d') || arg.startsWith('--depth'));
+var depth = dirtyDepth.length > 0 ? parseInt(dirtyDepth[0].split('=')[1], 10) : Infinity;
 
 sortJson.overwrite(
   files.map(function (f) {
     return path.resolve(f);
   }),
-  { ignoreCase, reverse }
+  { ignoreCase, reverse, depth }
 );

--- a/app/visit.js
+++ b/app/visit.js
@@ -6,6 +6,7 @@
  * @param [options.reverse = false]         - When sorting keys, converts all keys to lowercase so
  *                                            that capitalization doesn't interfere with sort order
  * @param [options.ignoreCase = false]      - When sorting keys, converts all keys to
+ * @param [options.depth = Infinity]           - Depth's level sorting keys on a multidimensional object
  * @returns {*}                             - Object with sorted keys, if old wasn't an object
  *                                            returns whatever was passed
  */
@@ -13,24 +14,32 @@ function visit(old, options) {
   options = options || {};
   var ignoreCase = options.ignoreCase || false;
   var reverse = options.reverse || false;
+  var depth = options.depth || Infinity;
+  var level = options.level || 1;
+  var processing = level <= depth;
 
   if (typeof(old) !== 'object' || old === null) {
     return old;
   }
 
   var copy = Array.isArray(old) ? [] : {};
-  var keys = ignoreCase ?
-    Object.keys(old).sort(function (a, b) {
-      return a.toLowerCase().localeCompare(b.toLowerCase());
-    }) :
-    Object.keys(old).sort();
+  var keys = Object.keys(old);
+  if(processing) {
+    keys = ignoreCase ?
+      keys.sort(function (a, b) {
+        return a.toLowerCase().localeCompare(b.toLowerCase());
+      }) :
+      keys.sort();
+  }
 
   if (reverse) {
     keys = keys.reverse();
   }
 
-  keys.forEach(function (key) {
+  keys.forEach(function (key, i) {
+    options.level = ++level;
     copy[key] = visit(old[key], options);
+    options.level = --level;
   });
 
   return copy;

--- a/tests/cmd.js
+++ b/tests/cmd.js
@@ -47,6 +47,45 @@ describe('cmd', () => {
     expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile2, 'utf8')))).to.equal(JSON.stringify(expectedData));
   });
 
+  it('sorts object by keys with depth not set', () => {
+    const givenData = { def: 456, abc: { b: 1, a: 2 }, hij: 789 };
+    const expectedData = { abc: { a: 2, b: 1 }, def: 456, hij: 789 };
+
+    fs.writeFileSync(tempFile, JSON.stringify(givenData), 'utf8');
+    cp.execSync(`node ${path.resolve(__dirname, '../app/cmd')} ${tempFile}`);
+
+    // parse then stringify to remove white space issues
+    expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile, 'utf8')))).to.equal(JSON.stringify(expectedData));
+  });
+
+  it('sorts object by keys with depth = 1', () => {
+    const givenData = { def: 456, abc: { b: 1, a: 2 }, hij: 789 };
+    const expectedData = { abc: { b: 1, a: 2 }, def: 456, hij: 789 };
+
+    fs.writeFileSync(tempFile, JSON.stringify(givenData), 'utf8');
+    fs.writeFileSync(tempFile2, JSON.stringify(givenData), 'utf8');
+    cp.execSync(`node ${path.resolve(__dirname, '../app/cmd')} ${tempFile} -d=1`);
+    cp.execSync(`node ${path.resolve(__dirname, '../app/cmd')} ${tempFile2} --depth=1`);
+
+    // parse then stringify to remove white space issues
+    expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile, 'utf8')))).to.equal(JSON.stringify(expectedData));
+    expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile2, 'utf8')))).to.equal(JSON.stringify(expectedData));
+  });
+
+  it('sorts object by keys with depth = 2', () => {
+    const givenData = { def: 456, abc: { b: 1, a: 2 }, hij: 789 };
+    const expectedData = { abc: { a: 2, b: 1 }, def: 456, hij: 789 };
+
+    fs.writeFileSync(tempFile, JSON.stringify(givenData), 'utf8');
+    fs.writeFileSync(tempFile2, JSON.stringify(givenData), 'utf8');
+    cp.execSync(`node ${path.resolve(__dirname, '../app/cmd')} ${tempFile} -d=2`);
+    cp.execSync(`node ${path.resolve(__dirname, '../app/cmd')} ${tempFile2} --depth=2`);
+
+    // parse then stringify to remove white space issues
+    expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile, 'utf8')))).to.equal(JSON.stringify(expectedData));
+    expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile2, 'utf8')))).to.equal(JSON.stringify(expectedData));
+  });
+
   it('sorts object by keys and ignores case if ignoreCase enabled', () => {
     const givenData = { foo: 123, bar: 456, baz: 789, Quax: 999, Foo2: 123 };
     const expectedData = { bar: 456, baz: 789, foo: 123, Foo2: 123, Quax: 999 };

--- a/tests/visit.js
+++ b/tests/visit.js
@@ -39,6 +39,29 @@ describe('visit', () => {
     expect(JSON.stringify(visit(givenData, opts))).to.equal(JSON.stringify(expectedData));
   });
 
+  it('sorts object by keys with depth not set', () => {
+    const givenData = { def: 456, abc: { b: 1, a: 2 }, hij: 789 };
+    const expectedData = { abc: { a: 2, b: 1 }, def: 456, hij: 789 };
+
+    expect(JSON.stringify(visit(givenData))).to.equal(JSON.stringify(expectedData));
+  });
+
+  it('sorts object by keys with depth = 1', () => {
+    const opts = { depth: 1 };
+    const givenData = { def: 456, abc: { b: 1, a: 2 }, hij: 789 };
+    const expectedData = { abc: { b: 1, a: 2 }, def: 456, hij: 789 };
+
+    expect(JSON.stringify(visit(givenData, opts))).to.equal(JSON.stringify(expectedData));
+  });
+
+  it('sorts object by keys with depth = 2', () => {
+    const opts = { depth: 2 };
+    const givenData = { def: 456, abc: { b: 1, a: 2 }, hij: 789 };
+    const expectedData = { abc: { a: 2, b: 1 }, def: 456, hij: 789 };
+
+    expect(JSON.stringify(visit(givenData, opts))).to.equal(JSON.stringify(expectedData));
+  });
+
   it('sorts object by keys and ignores case if ignoreCase enabled', () => {
     const opts = { ignoreCase: true };
     const givenData = { foo: 123, bar: 456, baz: 789, Quax: 999, Foo2: 123 };


### PR DESCRIPTION
Hi,
If you have a multidimensional object and you just want to sort the
first level, you can use --depth=1.
My use case was translation's files where I wanted the keys to be sorted
but not the translated object:
```json
{
  "key2": {
    "message": "translation2",
    "description": "Option"
  },
  "key1": {
    "message": "translation",
    "description": "Option"
  }
}
```