### PR TITLE
Adds detect indentation and CLI option to set indent size. (Closes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
+
 sort-json
 =========
 
 It takes a JSON file and returns a copy of the same file, but with the sorted keys.
 
-installation
+Installation
 ------------
 
 ` [sudo] npm -g install sort-json`
 
 
-usage
+Usage
 -----
 
 ```js
 const sortJson = require('sort-json');
 
-const options1 = { ignoreCase: true, reverse: true, depth: 1 };
-const copy = sortJson({ AA: 123, a: 1, b: 21 }, options1);
+const options = { ignoreCase: true, reverse: true, depth: 1};
+const copy = sortJson({ AA: 123, a: 1, b: 21 }, options);
 // copy => { b: 21, AA: 123, a: 1 }
 
 sortJson.overwrite('some/absolute/path.json');
@@ -28,15 +29,35 @@ sortJson.overwrite(['some/absolute/path1.json', 'some/absolute/path2.json']);
 
 CLI usage
 ---------
-`sort-json file.json` => sorts and overwrites file.json
+`sort-json filename [options]`
+Sorts and overwrites .json or .rc files.
 
-`-i` or `--ignore-case` to ignore case when sorting.
+_Example_
+`sort-json test.json --ignore-case`
 
-`-r` or `--reverse` to reverse order z -> a
+ **Options**
 
-`-d` or `--depth` to chose the sorting depth on multidimensional objects
+`-i, --ignore-case`
+Ignore case when sorting.
 
-tests
+`-r, --reverse`
+Reverse the ordering z -> a
+
+`-d, --depth=DEPTH`
+The sorting _DEPTH_ on multidimensional objects.
+Use a number greater then 0 for the _DEPTH_ value.
+
+`--indent-size=SIZE, --spaces=SIZE`
+Formats the file content with an indentation of _SIZE_ spaces  (default: detects the used indentation of the file).
+Use a number greater then 0 for the _SIZE_ value.
+
+Upgrade to version 2.x
+----------------------
+
+sort-json 2.0.0 will create a different output when the source JSON file does not use an indent size of 2 spaces.
+Use `--indent-size=2` to always create an output file with 2 spaces.
+
+Tests
 -----
 
 `npm test`

--- a/app/cmd.js
+++ b/app/cmd.js
@@ -1,22 +1,22 @@
 #!/usr/bin/env node
 
-/* eslint-disable no-use-before-define */
-
 // Core dependencies
 const path = require('path');
-const _ = require('lodash');
 
 // NPM dependencies
+const minimist = require('minimist');
 const sortJson = require('./');
 
-// Get all the files
-const files = process.argv.slice(0).filter(arg => arg.endsWith('.json') || arg.endsWith('.rc'));
-const ignoreCase = _.includes(process.argv, '--ignore-case') || _.includes(process.argv, '-i');
-const reverse = _.includes(process.argv, '--reverse') || _.includes(process.argv, '-r');
-const dirtyDepth = process.argv.slice(0).filter(arg => arg.startsWith('-d') || arg.startsWith('--depth'));
-const depth = dirtyDepth.length > 0 ? parseInt(dirtyDepth[0].split('=')[1], 10) : Infinity;
+const alias = {
+  depth: ['d'],
+  reverse: ['r'],
+  ignoreCase: ['ignore-case', 'i'],
+  indentSize: ['indent-size', 'spaces'],
+};
 
-sortJson.overwrite(
-  files.map(file => path.resolve(file)),
-  { ignoreCase, reverse, depth }
-);
+const argv = minimist(process.argv.slice(2), { alias });
+
+// Get all the files
+const files = argv._.filter(arg => arg.endsWith('.json') || arg.endsWith('.rc'));
+
+sortJson.overwrite(files.map(file => path.resolve(file)), argv);

--- a/app/overwrite.js
+++ b/app/overwrite.js
@@ -1,6 +1,9 @@
 const fs = require('fs');
+const detectIndent = require('detect-indent');
 
 const visit = require('./visit');
+
+const DEFAULT_INDENT_SIZE = 2;
 
 /**
  * Overwrite file with sorted json
@@ -9,14 +12,27 @@ const visit = require('./visit');
  * @returns {*}
  */
 function overwriteFile(path, options) {
+  let fileContent = null;
   let newData = null;
+
   try {
-    newData = visit(JSON.parse(fs.readFileSync(path, 'utf8')), options);
+    fileContent = fs.readFileSync(path, 'utf8');
+    newData = visit(JSON.parse(fileContent), options);
   } catch (e) {
     console.error('Failed to retrieve json object from file');
     throw e;
   }
-  const newJson = JSON.stringify(newData, null, 2);
+
+  let indent;
+
+  if (options && options.indentSize) {
+    indent = options.indentSize;
+  } else {
+    indent = detectIndent(fileContent).indent || DEFAULT_INDENT_SIZE;
+  }
+
+  const newJson = JSON.stringify(newData, null, indent);
+
   // append new line at EOF
   const content = newJson[newJson.length - 1] === '\n' ? newJson : `${newJson}\n`;
   fs.writeFileSync(path, content, 'utf8');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1040,7 +1040,8 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Takes a json-file and return a copy of the same file, but sorted",
   "main": "index.js",
   "dependencies": {
-    "lodash": "^4.17.10"
+    "detect-indent": "^5.0.0",
+    "minimist": "^1.2.0"
   },
   "bin": {
     "sort-json": "./app/cmd.js"

--- a/tests/cmd.js
+++ b/tests/cmd.js
@@ -99,4 +99,16 @@ describe('cmd', () => {
     expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile, 'utf8')))).to.equal(JSON.stringify(expectedData));
     expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile2, 'utf8')))).to.equal(JSON.stringify(expectedData));
   });
+
+  it('sorts object by keys and uses given indent size', () => {
+    const givenData = { foo: 123, bar: 456 };
+
+    fs.writeFileSync(tempFile, JSON.stringify(givenData), 'utf8');
+    cp.execSync(`node ${path.resolve(__dirname, '../app/cmd')} ${tempFile} --indent-size=3`);
+
+    // parse then stringify to remove white space issues
+    const expectedData = { bar: 456, foo: 123};
+    const expectedFileContent = JSON.stringify(expectedData, null, 3) + '\n';
+    expect(fs.readFileSync(tempFile, 'utf8')).to.equal(expectedFileContent);
+  });
 });

--- a/tests/overwrite.js
+++ b/tests/overwrite.js
@@ -61,4 +61,14 @@ describe('overwrite', () => {
     // parse then stringify to remove white space issues
     expect(JSON.stringify(JSON.parse(fs.readFileSync(tempFile, 'utf8')))).to.equal(JSON.stringify(expectedData));
   });
+
+  it('persists the indentation when modifying the file', () => {
+    const givenData = { foo: 123 };
+
+    fs.writeFileSync(tempFile, JSON.stringify(givenData, null, 4), 'utf8');
+    sortJson.overwrite(tempFile);
+
+    const result = fs.readFileSync(tempFile, 'utf8');
+    expect(result).to.equal('{\n    "foo": 123\n}\n');
+  });
 });


### PR DESCRIPTION
This PR will solve https://github.com/kesla/sort-json/issues/21

**What's new**

* Persists (respects) the indentation used in the source file. 
* Adds a new CLI option `--ident-size` to set a specific indentation (to prevent detect)
* A little reformat of the README.md

**Side effects**

Unfortunately adding the detect indent will result in a breaking change, so the version number needs to be bumped to 2.0.0 - The breaking change scenario and a migration is described in the README.md

---

**Roadmap?**

I would like to provide at least two more PR for doing the same thing for line endings and the last empty line in the file. Also this PRs will eventually be breaking.

So after merging this PR, you can wait for the next two and then release a 2.0.0 version to NPM, otherwise we will eventually have a 3.0.0 and 4.0.0

What do you think?



