### PR TITLE
Whitelist npm package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "type": "git",
     "url": "https://github.com/kesla/sort-json.git"
   },
+  "files": [
+    "app"
+  ],
   "author": "David Björklund <david.bjorklund@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
The npm package currently contains the following files:
```
├── app
│   ├── cmd.js
│   ├── index.js
│   ├── overwrite.js
│   └── visit.js
├── .editorconfig
├── .eslintrc
├── index.js
├── LICENSE
├── package.json
├── README.md
├── tests
│   ├── cmd.js
│   ├── overwrite.js
│   └── visit.js
└── .travis.yml

```

Files such as `tests/*`, `.editorconfig`, and`.eslintrc` do not serve a purpose for consumers of the package while increasing package size. Therefore, I've whitelisted the files that are required for the package to run.

`index.js`, `README.md` and `LICENSE` are [included by default](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files). Test using [`npm pack`](https://docs.npmjs.com/cli/v8/commands/npm-pack).