### PR TITLE
Draft: Avoid going deeper if not needed

### DIFF
--- a/app/visit.js
+++ b/app/visit.js
@@ -20,7 +20,7 @@ function visit(old, options) {
   const level = sortOptions.level || 1;
   const processing = level <= depth;
 
-  if (typeof (old) !== 'object' || old === null) {
+  if (typeof (old) !== 'object' || old === null || (!processing && !reverse)) {
     return old;
   }
 


### PR DESCRIPTION
I'm running out of memory when sorting a big, deep, json file. I noticed that even though I set `depth` to a small number, I'm still running out of memory.

The proposed performance optimization stops the recursion when the depth is reached. This should

* use less memory
* compute faster

The proposed solution is not tested (yet), that's why I marked it as a draft. I'm also not sure if it is on purpose to reverse the keys even when the depth is reached => if it's a bug, then ` && !reverse` can be removed to fix the bug.

@kesla what are your thoughts on this?